### PR TITLE
docker: Set spack compiler explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ COPY --chmod=0755 <<-"EOF" dostarenv.sh
 	set -e
 	source /star-spack/setup.sh
 	rm -f $HOME/.spack/mirrors.yaml
+	spack compiler add $(dirname $(which gcc))
 	spack mirror add buildcache /opt/buildcache
 	spack buildcache update-index -d /opt/buildcache
 	spack env create ${1} /star-spack/environments/${1}.yaml


### PR DESCRIPTION
Address an issue with consecutive calls of `dostarenv.sh` when the wrong version of compiler is selected