### PR TITLE
docker: Load libiconv to be discovered by STAR's StDbLib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN ./dostarenv.sh star-x86_64-loose && ./dostarenv.sh ${starenv}
 # Manually append specific modules to loads
 RUN <<-EOF
 	source /star-spack/setup.sh
-	spack -e star-x86_64-loose module tcl loads py-pyparsing@2.2 python@2.7 vc@0.7.4 >> /star-spack/spack/var/spack/environments/${starenv}/loads
+	spack -e star-x86_64-loose module tcl loads py-pyparsing@2.2 python@2.7 vc@0.7.4 libiconv >> /star-spack/spack/var/spack/environments/${starenv}/loads
 EOF
 
 # Strip all the binaries


### PR DESCRIPTION
```
$ root4star -l -b -q 'StRoot/macros/analysis/find_vertex.C("/star/rcf/test/daq/2020/351/st_physics_20351078_raw_5000001.event.root")'
root [0]
...
Processing StRoot/macros/analysis/find_vertex.C("/star/rcf/test/daq/2020/351/st_physics_20351078_raw_5000001.event.root")...
...
dlopen error: libiconv.so.2: cannot open shared object file: No such file or directory
Load Error: Failed to load Dynamic link library /star-sw/.sl79_gcc485/LIB/StDbLib.so
...
```