### PR TITLE
build: improve Spack cache reuse and runtime image setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ SHELL ["/bin/bash", "-l", "-c"]
 COPY --from=build-stage /cern /cern
 COPY --from=build-stage /etc/profile.d /etc/profile.d
 COPY --from=build-stage /opt/software /opt/software
-COPY --from=build-stage /star-spack/spack/share/spack/modules/linux-scientific7-x86_64_v3 /opt/linux-scientific7-x86_64
+COPY --from=build-stage /star-spack/spack/share/spack/modules/linux-scientific7-x86_64 /opt/linux-scientific7-x86_64
 
 RUN sed -i 's/scientificlinux.org\/linux\/scientific\//scientificlinux.org\/linux\/scientific\/obsolete\//g' /etc/yum.repos.d/*
 RUN yum update -q -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,8 @@ COPY --chmod=0755 <<-"EOF" dostarenv.sh
 	spack env deactivate
 EOF
 
-RUN --mount=type=cache,target=/spack-buildcache ./dostarenv.sh star-loose
-RUN --mount=type=cache,target=/spack-buildcache ./dostarenv.sh ${starenv}
+RUN --mount=type=cache,id=star-spack-buildcache,target=/spack-buildcache,sharing=locked ./dostarenv.sh star-loose
+RUN --mount=type=cache,id=star-spack-buildcache,target=/spack-buildcache,sharing=locked ./dostarenv.sh ${starenv}
 
 # Strip all the binaries
 RUN find -L /opt/software/* -type f -exec readlink -f '{}' \; | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,13 +103,6 @@ FROM ${baseimg_os} AS starenv-stage
 ARG starenv
 ARG compiler
 
-SHELL ["/bin/bash", "-l", "-c"]
-
-COPY --from=build-stage /cern /cern
-COPY --from=build-stage /etc/profile.d /etc/profile.d
-COPY --from=build-stage /opt/software /opt/software
-COPY --from=build-stage /star-spack/spack/share/spack/modules/linux-scientific7-x86_64 /opt/linux-scientific7-x86_64
-
 RUN sed -i 's/scientificlinux.org\/linux\/scientific\//scientificlinux.org\/linux\/scientific\/obsolete\//g' /etc/yum.repos.d/*
 RUN yum update -q -y \
  && yum install -y \
@@ -120,6 +113,14 @@ RUN yum update -q -y \
     libX11-devel libXext-devel libXpm-devel libXt-devel \
     environment-modules \
  && yum clean all
+
+# Copy the generated activation scripts only after the `module` command is installed
+COPY --from=build-stage /cern /cern
+COPY --from=build-stage /etc/profile.d /etc/profile.d
+COPY --from=build-stage /opt/software /opt/software
+COPY --from=build-stage /star-spack/spack/share/spack/modules/linux-scientific7-x86_64 /opt/linux-scientific7-x86_64
+
+SHELL ["/bin/bash", "-l", "-c"]
 
 ENV MODULEPATH=/opt/linux-scientific7-x86_64
 ENV USE_64BITS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ COPY --chmod=0755 <<-"EOF" dostarenv.sh
 	spack env create ${1} /star-spack/environments/${1}.yaml
 	spack env activate ${1}
 	spack --insecure install --no-check-signature || true
-	spack buildcache create --allow-root --unsigned --force --rebuild-index --directory /spack-buildcache $(spack find --no-groups --format "/{hash}")
+	spack buildcache create --allow-root --unsigned --directory /spack-buildcache $(spack find --no-groups --format "/{hash}")
+	spack buildcache update-index --mirror-url file:///spack-buildcache
 	spack module tcl refresh -y
 	spack env deactivate
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,12 +78,21 @@ EOF
 RUN --mount=type=cache,id=star-spack-buildcache,target=/spack-buildcache,sharing=locked ./dostarenv.sh star-loose
 RUN --mount=type=cache,id=star-spack-buildcache,target=/spack-buildcache,sharing=locked ./dostarenv.sh ${starenv}
 
-# Strip all the binaries
-RUN find -L /opt/software/* -type f -exec readlink -f '{}' \; | \
-    xargs file -i | \
-    grep 'charset=binary' | \
-    grep 'x-executable\|x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs strip -S
+# Reduce the runtime image size while keeping static archives usable for
+# downstream linking.
+RUN find /opt/software -type f -exec sh -c ' \
+    for file do \
+        description=$(file -b "$file"); \
+        case "$description" in \
+            *ELF*"executable"*|*ELF*"shared object"*) \
+                strip --strip-unneeded "$file" \
+                ;; \
+            *"current ar archive"*) \
+                strip --strip-debug "$file" \
+                ;; \
+        esac; \
+    done \
+    ' sh {} +
 
 # Load only the umbrella star-env module
 RUN spack -e ${starenv} module tcl loads star-env >> /etc/profile.d/z10_load_spack_env_modules.sh


### PR DESCRIPTION
## Summary

Improve Docker image build performance, buildcache safety, runtime image size, and environment-module initialization.

## Changes

- Assign a stable `star-spack-buildcache` ID to the BuildKit cache mount.
- Lock buildcache access to prevent concurrent package and index writes.
- Preserve existing binary packages instead of recreating them with `--force`.
- Rebuild the Spack buildcache index once after adding missing packages.
- Strip unneeded symbols from ELF executables and shared libraries while preserving static archives for downstream linking.
- Correct the generated Spack module directory used by the runtime image.
- Install `environment-modules` before copying activation scripts.
- Enable login-shell execution only after runtime dependencies and profile scripts are in place, preventing `module: command not found` warnings.

## Validation

Successfully built the complete runtime stage with:

```bash
docker build --build-arg starenv=root5 --build-arg compiler=gcc485 .
docker build --build-arg starenv=root6 --build-arg compiler=gcc485 .
docker build --build-arg starenv=root5 --build-arg compiler=gcc11 .
docker build --build-arg starenv=root6 --build-arg compiler=gcc11 .
```
