### PR TITLE
fix(env): remove obsolete Python 3.6 specs

### DIFF
--- a/environments/star-loose.yaml
+++ b/environments/star-loose.yaml
@@ -16,7 +16,6 @@ spack:
     - cmake
     - git
     - python@2.7 ^libffi@3.2.1
-    - python@3.6 ^libffi@3.2.1
     - python@3.8 ^libffi@3.2.1
     - py-pyparsing@2.2.0 ^python@2.7 ^libffi@3.2.1
     - vc@1.4.1

--- a/environments/star-x86-loose.yaml
+++ b/environments/star-x86-loose.yaml
@@ -8,7 +8,6 @@ spack:
     - $spack/../environments/modules.yaml
   specs:
     - python@2.7 ^libffi@3.2.1
-    - python@3.6 ^libffi@3.2.1
     - python@3.8 ^libffi@3.2.1
     - py-pyparsing@2.2.0 ^python@2.7 ^libffi@3.2.1
     - vc@1.4.1


### PR DESCRIPTION
Python 3.6 was added in c3d9c9b for the temporary 32-bit ROOT 5 PyROOT
configuration, because that ROOT version could not use Python 3.7 or newer.

Since 8ba817c, both ROOT 5 environments explicitly disable Python bindings.
Python 3.8 remains available as the current Python 3 runtime and is reused by
ROOT 6 for PyROOT, while star-env continues to load Python 2.7 where required.

Remove the stale specs from both loose environments to avoid building an
end-of-life interpreter and hitting its GCC 11 ensurepip alignment crash.
