### PR TITLE
fix(build): force fresh Spack concretization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ COPY --chmod=0755 <<-"EOF" dostarenv.sh
 	spack env create "${environment}" "/star-spack/environments/${environment}.yaml"
 	spack env activate "${environment}"
 	install_status=0
-	spack --insecure install --no-check-signature --reuse || install_status=$?
+	spack --insecure install --no-check-signature --fresh || install_status=$?
 	mapfile -t installed_hashes < <(spack find --no-groups --format "/{hash}")
 	if ((${#installed_hashes[@]})); then
 		spack buildcache create --allow-root --unsigned --rebuild-index --directory "${cache_dir}" "${installed_hashes[@]}"


### PR DESCRIPTION
Replace --reuse with --fresh when installing container environments so
Spack evaluates the current package recipes and dependency declarations.

The shared buildcache may contain concrete specs created from older
recipes. Reusing such a spec allowed star-env@0.4.0 to retain its old
dependency graph, preventing the newly added CLHEP dependency from being
autoloaded into the runtime environment.

Fresh concretization still permits installation of matching binaries
from the buildcache while preventing stale dependency graphs from being
selected.
